### PR TITLE
Correct which links are shown for different users

### DIFF
--- a/src/app/dashboard/transaction-log.component.html
+++ b/src/app/dashboard/transaction-log.component.html
@@ -101,7 +101,7 @@
         <div class="card-header">
           <strong>Log of Outgoing Transactions</strong>
           <small>This lists all purchases that have been submitted.</small>
-            <button class="btn pull-right btn-sm" (click)="toggleShowMeta()">
+            <button *ngIf="accountType == 'organisation'" class="btn pull-right btn-sm" (click)="toggleShowMeta()">
               <span *ngIf="!showMeta">Show</span><span *ngIf="showMeta">Hide</span> Details
             </button>
         </div>

--- a/src/app/dashboard/transaction-log.component.ts
+++ b/src/app/dashboard/transaction-log.component.ts
@@ -29,6 +29,7 @@ export class TransactionLogComponent implements OnInit {
   transactionFormStatusSuccess: string;
   transactionFormStatusError = 'Error received, please try again.';
   updatedTime: string;
+  accountType: any;
   showMeta = false;
 
   public paginateConfig: PaginationInstance = {
@@ -58,6 +59,7 @@ export class TransactionLogComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadTransactions(1);
+    this.accountType = localStorage.getItem('usertype');
   }
 
   loadTransactions(logPage: number) {

--- a/src/app/layouts/full-layout.component.html
+++ b/src/app/layouts/full-layout.component.html
@@ -38,7 +38,7 @@
             </div>
           </a>
         </li>
-        <li class="nav-item">
+        <li *ngIf="accountType == 'organisation'" class="nav-item">
           <a class="nav-link" routerLinkActive="active" [routerLink]="['/more-graphs-and-tables']">
             <div class="row no-gutters align-items-center">
               <div class="col-2"><i class="icon-map"></i></div>
@@ -94,7 +94,7 @@
             </div>
           </a>
         </li>
-        <li class="nav-item">
+        <li *ngIf="accountType == 'customer'" class="nav-item">
           <a class="nav-link" routerLinkActive="active" [routerLink]="['/category-month']">
             <div class="row no-gutters align-items-center">
               <div class="col-2"><i class="icon-basket"></i></div>
@@ -102,7 +102,7 @@
             </div>
           </a>
         </li>
-        <li class="nav-item">
+        <li *ngIf="accountType == 'organisation'" class="nav-item">
             <a class="nav-link" routerLinkActive="active" [routerLink]="['/suppliers']">
               <div class="row no-gutters align-items-center">
                 <div class="col-2"><i class="icon-speedometer"></i></div>


### PR DESCRIPTION
- The ‘Infographics’ and ‘Suppliers’ links are no longer displayed in the sidebar for customers
- The ‘Budget’ link is no longer displayed in the sidebar for organisations
- The ‘Show Details’ button on the ‘Log of Outgoing Transactions’ table is no longer displayed for customers

Closes #104 