### PR TITLE
Capitalise entered postcodes

### DIFF
--- a/src/app/auth/register.component.ts
+++ b/src/app/auth/register.component.ts
@@ -70,7 +70,7 @@ export class RegisterComponent {
     password:      signupForm.password,
     display_name:  customerForm.display_name,
     full_name:     customerForm.full_name,
-    postcode:      customerForm.postcode,
+    postcode:      customerForm.postcode.toUpperCase(),
     year_of_birth: customerForm.year_of_birth,
   };
   console.log(data);
@@ -114,7 +114,7 @@ export class RegisterComponent {
     sector:       organisationForm.sector,
     street_name:  organisationForm.street_name,
     town:         organisationForm.town,
-    postcode:     organisationForm.postcode,
+    postcode:     organisationForm.postcode.toUpperCase(),
   };
   this.api
       .register(data)

--- a/src/app/dashboard/account-edit.component.ts
+++ b/src/app/dashboard/account-edit.component.ts
@@ -89,7 +89,7 @@ export class AccountEditComponent implements OnInit {
 
   const submitData = {
     email:        settingForm.email,
-    postcode:     settingForm.postcode,
+    postcode:     settingForm.postcode.toUpperCase(),
     password:     settingForm.password,
     new_password: settingForm.new_password,
     name:         settingOrganisationForm.name,
@@ -142,7 +142,7 @@ export class AccountEditComponent implements OnInit {
 
   const submitData = {
     email:        settingForm.email,
-    postcode:     settingForm.postcode,
+    postcode:     settingForm.postcode.toUpperCase(),
     password:     settingForm.password,
     new_password: settingForm.new_password,
     full_name:    settingCustomerForm.full_name,


### PR DESCRIPTION
Postcodes entered with lower-case letter are now capitalised before submission, whereas before they would cause submission to fail.

Closes #105 